### PR TITLE
[story/TP-103678] Api test fixes - getting returned value when should be empty

### DIFF
--- a/lib/dm-core/property.rb
+++ b/lib/dm-core/property.rb
@@ -673,10 +673,12 @@ module DataMapper
 
     # @api semipublic
     def typecast(value)
-      if (value.nil? || value_loaded?(value)) && !respond_to?(:typecast_to_primitive, true)
+      if value.nil? || value_loaded?(value)
         value
       elsif respond_to?(:typecast_to_primitive, true)
         typecast_to_primitive(value)
+      else
+        value
       end
     end
 

--- a/lib/dm-core/property/object.rb
+++ b/lib/dm-core/property/object.rb
@@ -11,6 +11,8 @@ module DataMapper
 
       # @api semipublic
       def load(value)
+        return if value.nil?
+
         typecast(instance_of?(Object) ? unmarshal(value) : value)
       end
 

--- a/lib/dm-core/property/object.rb
+++ b/lib/dm-core/property/object.rb
@@ -11,8 +11,6 @@ module DataMapper
 
       # @api semipublic
       def load(value)
-        return if value.nil?
-
         typecast(instance_of?(Object) ? unmarshal(value) : value)
       end
 

--- a/lib/dm-core/version.rb
+++ b/lib/dm-core/version.rb
@@ -1,3 +1,3 @@
 module DataMapper
-  VERSION = '1.6.0'.freeze
+  VERSION = '1.7.0'.freeze
 end

--- a/lib/dm-core/version.rb
+++ b/lib/dm-core/version.rb
@@ -1,3 +1,3 @@
 module DataMapper
-  VERSION = '1.7.0'.freeze
+  VERSION = '1.8.0'.freeze
 end


### PR DESCRIPTION
Added in a guard clause to the load method so that it doesn't typecast nil to incorrect values.